### PR TITLE
feat: Update vcert to latest v5.7.1

### DIFF
--- a/Formula/vcert.rb
+++ b/Formula/vcert.rb
@@ -1,33 +1,33 @@
 class Vcert < Formula
   desc "Venafi Machine Identity Services Golang CLI and SDK"
   homepage "https://github.com/Venafi/vcert"
-  url "https://github.com/Venafi/vcert/archive/refs/tags/v5.6.4.tar.gz"
+  url "https://github.com/Venafi/vcert/archive/refs/tags/v5.7.1.tar.gz"
   license "Apache-2.0"
-  head "https://github.com/venafi/vcert.git", tag: "v5.6.4"
+  head "https://github.com/venafi/vcert.git", tag: "v5.7.1"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/Venafi/vcert/releases/download/v5.6.4/vcert_v5.6.4_darwin.zip"
-      sha256 "b0f0f1fb027fa8550012b9e55ad26ad71bb89f0c38100663c612779eca25127e"
+      url "https://github.com/Venafi/vcert/releases/download/v5.7.1/vcert_v5.7.1_darwin.zip"
+      sha256 "08469ce83ee816ea01a2341d26b659c44330839d96ca036406611f9bc37791f5"
     end
     if Hardware::CPU.arm?
-      url "https://github.com/Venafi/vcert/releases/download/v5.6.4/vcert_v5.6.4_darwin_arm.zip"
-      sha256 "45f96c336724690bab93228ff601ca8e0707320024515b9e3d692c9fbef5c0e5"
+      url "https://github.com/Venafi/vcert/releases/download/v5.7.1/vcert_v5.7.1_darwin_arm.zip"
+      sha256 "199be7c17762e353f9734eba9718d98e1708b0377dee82787913b79efc495c02"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
-      url "https://github.com/Venafi/vcert/releases/download/v5.6.4/vcert_v5.6.4_linux.zip"
-      sha256 "0083232c294a01d8c45f3c4b476c1fff9241eb15508a94327b58e36800d4ba77"
+      url "https://github.com/Venafi/vcert/releases/download/v5.7.1/vcert_v5.7.1_linux.zip"
+      sha256 "a015f0700fd2677a7a82d54d4b1915f649a0dbbebc6b2a0fe7642a017c89eea8"
     end
     if Hardware::CPU.intel? && Hardware::CPU.is_32_bit?
-      url "https://github.com/Venafi/vcert/releases/download/v5.6.4/vcert_v5.6.4_linux86.zip"
-      sha256 "12ea3030b5895989bd6fd494e40bfdac9d5c6fafbba72a1fbc0e6302209db52f"
+      url "https://github.com/Venafi/vcert/releases/download/v5.7.1/vcert_v5.7.1_linux86.zip"
+      sha256 "1e47ed1b18d8d4f6b5b7a028c03e1e3f025529ce8e25e49cf1f36fb8f2d34fad"
     end
     if Hardware::CPU.arm?
-      url "https://github.com/Venafi/vcert/releases/download/v5.6.4/vcert_v5.6.4_linux_arm.zip"
-      sha256 "993449c30c994aaf128f0e820d03169cd233545127e22b803a133d890c212cc3"
+      url "https://github.com/Venafi/vcert/releases/download/v5.7.1/vcert_v5.7.1_linux_arm.zip"
+      sha256 "94955a45af5023e3016248f362da074512786a95977aa4e0c5df702addbbaf58"
     end
   end
 


### PR DESCRIPTION
I've manually checked the sha256's locally from the release files, and updated the versions:

```shell
> ls -ltr ~/Downloads | tail -8
-rw-r--r--@    1 peter.fiddes  staff    4408145 22 Jul 13:40 vcert_v5.7.1_darwin.zip
-rw-r--r--@    1 peter.fiddes  staff    4190511 22 Jul 13:40 vcert_v5.7.1_darwin_arm.zip
-rw-r--r--@    1 peter.fiddes  staff    4258304 22 Jul 13:40 vcert_v5.7.1_linux.zip
-rw-r--r--@    1 peter.fiddes  staff    4017745 22 Jul 13:40 vcert_v5.7.1_linux86.zip
-rw-r--r--@    1 peter.fiddes  staff    3862018 22 Jul 13:40 vcert_v5.7.1_linux_arm.zip
-rw-r--r--@    1 peter.fiddes  staff    4400227 22 Jul 13:40 vcert_v5.7.1_windows.zip
-rw-r--r--@    1 peter.fiddes  staff    4232371 22 Jul 13:40 vcert_v5.7.1_windows86.zip
-rw-r--r--@    1 peter.fiddes  staff    3962593 22 Jul 13:40 vcert_v5.7.1_windows_arm.zip

# eg.
> sha256sum vcert_v5.7.1_darwin.zip
08469ce83ee816ea01a2341d26b659c44330839d96ca036406611f9bc37791f5  vcert_v5.7.1_darwin.zip
```

I don't know how to test manually, but I assume I can point to my fork and tap that repo instead?

Signed-off-by: Peter Fiddes <peter.fiddes@venafi.com>
