### PR TITLE
Update to venctl v1.15.1

### DIFF
--- a/Formula/venctl.rb
+++ b/Formula/venctl.rb
@@ -2,26 +2,26 @@ class Venctl < Formula
   desc "Venafi CLI serves as an alternative to the Venafi Control Plane web interface"
   homepage "https://docs.venafi.cloud/vaas/venctl/c-venctl-overview"
   url "https://docs.venafi.cloud/vaas/venctl/c-venctl-releases"
-  version "1.15.0"
+  version "1.15.1"
   on_macos do
     if Hardware::CPU.intel?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-darwin-amd64.zip"
-      sha256 "ba5b366cbc8c18ed79d71d0b0ae6ba52c3dad48510262848903eb3c81aa50372"
+      sha256 "ab9dbb1381b41f8e3b541f32846ffd537fad5f541ddb472ccb13f26f49544dd9"
     end
     if Hardware::CPU.arm?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-darwin-arm64.zip"
-      sha256 "eb5ea50d8f1ac3467befe357240d3bdfccd1707e93c1a8dc86e0bc25d16344da"
+      sha256 "994774246cc7e3c4254b733b97d12e4aed57a4822268e62429351c34884fc709"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-linux-amd64.zip"
-      sha256 "ff8e9f041e7dc6b05c8a506d4b394917879ac48b8f17461d2fe3aaad0ef2935d"
+      sha256 "c1754c1b40fc2be8d29d5560332bb55af564633289b956e92298d0d10a89a6cd"
     end
     if Hardware::CPU.arm?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-linux-arm64.zip"
-      sha256 "9aa9119beaa4ceb3b8bf0e00551ac921eb34f361d1054a802c31fa61b9bd34b8"
+      sha256 "3f1888724e07cf2e8845034231540e118e6745c91c208ffd0c638c8e05ac4361"
     end
   end
 


### PR DESCRIPTION
From the following SHASUMs:

```ab9dbb1381b41f8e3b541f32846ffd537fad5f541ddb472ccb13f26f49544dd9  venctl-darwin-amd64.zip
994774246cc7e3c4254b733b97d12e4aed57a4822268e62429351c34884fc709  venctl-darwin-arm64.zip
c1754c1b40fc2be8d29d5560332bb55af564633289b956e92298d0d10a89a6cd  venctl-linux-amd64.zip
3f1888724e07cf2e8845034231540e118e6745c91c208ffd0c638c8e05ac4361  venctl-linux-arm64.zip
4a11828d0aeebf830a1671f55dbe2fd247a2dc7c4dce8f0ef96d613f2c51bdf8  venctl-windows-amd64.zip
```

Released today!