### PR TITLE
feat: Upgrade venctl to v1.21.0

### DIFF
--- a/Formula/venctl.rb
+++ b/Formula/venctl.rb
@@ -2,26 +2,26 @@ class Venctl < Formula
   desc "Venafi CLI serves as an alternative to the Venafi Control Plane web interface"
   homepage "https://docs.venafi.cloud/vaas/venctl/c-venctl-overview"
   url "https://docs.venafi.cloud/vaas/venctl/c-venctl-releases"
-  version "1.20.0"
+  version "1.21.0"
   on_macos do
     if Hardware::CPU.intel?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-darwin-amd64.zip"
-      sha256 "13997b5f499e05285e75b83978bc6f043957cfac9abcd49f8663a8f792906aee"
+      sha256 "0e8e11bba90c5e75c548c257924e8cc527bba90e77ae5742a17da0422b3e0134"
     end
     if Hardware::CPU.arm?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-darwin-arm64.zip"
-      sha256 "3a5e2d74638007877c307c3aec02f2d4585de76bb8e07db9414bdfaa16f95e45"
+      sha256 "f911a9258a44aacf7bbb18beae72be5e038fb44213eb856381f4f9b167be3cad"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-linux-amd64.zip"
-      sha256 "9754a6f95d28ed7271b123f5d54c89a3b313abf045985ba571e1e7d1dcafeb0d"
+      sha256 "09994b08d59e97f43d926f61548faed598aea73cd03c800b8b8a3a2cb29b304d"
     end
     if Hardware::CPU.arm?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-linux-arm64.zip"
-      sha256 "c6fd23c89da6fc9f0fb5b40edb1be12cc8db07395497466e83c592e1fd781c40"
+      sha256 "71daf08258fa8169441eafc6c19347b58400d2b9af34e1b9194815741ec2a30a"
     end
   end
 


### PR DESCRIPTION
Upgrade to the latest.

Just copied the relevant shas from the file provided on our website: https://dl.venafi.cloud/venctl/latest/venctl-SHA256SUMS