### PR TITLE
Update to venctl v1.22.0

### DIFF
--- a/Formula/venctl.rb
+++ b/Formula/venctl.rb
@@ -2,26 +2,26 @@ class Venctl < Formula
   desc "Venafi CLI serves as an alternative to the Venafi Control Plane web interface"
   homepage "https://docs.venafi.cloud/vaas/venctl/c-venctl-overview"
   url "https://docs.venafi.cloud/vaas/venctl/c-venctl-releases"
-  version "1.21.0"
+  version "1.22.0"
   on_macos do
     if Hardware::CPU.intel?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-darwin-amd64.zip"
-      sha256 "0e8e11bba90c5e75c548c257924e8cc527bba90e77ae5742a17da0422b3e0134"
+      sha256 "7a2190e9fb8cb7d2744b78778363e18dcc98a94351005fb76d6b8c64690ebecc"
     end
     if Hardware::CPU.arm?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-darwin-arm64.zip"
-      sha256 "f911a9258a44aacf7bbb18beae72be5e038fb44213eb856381f4f9b167be3cad"
+      sha256 "66b16db62286646d94bcd04548161ddea39fca079113e49b187490f6927671ae"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-linux-amd64.zip"
-      sha256 "09994b08d59e97f43d926f61548faed598aea73cd03c800b8b8a3a2cb29b304d"
+      sha256 "75aa9d17a2b3142e14b9f0cadac1c4df6dbe8be0d9ae2def68989da061458cef"
     end
     if Hardware::CPU.arm?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-linux-arm64.zip"
-      sha256 "71daf08258fa8169441eafc6c19347b58400d2b9af34e1b9194815741ec2a30a"
+      sha256 "d0ac7c24dd10c830a59517b4173ab71a3aebe093be663e06fd94c963c1ba7c9f"
     end
   end
 


### PR DESCRIPTION
Updated using the SHASUMs from release v1.22.0 today:

7a2190e9fb8cb7d2744b78778363e18dcc98a94351005fb76d6b8c64690ebecc  venctl-darwin-amd64.zip
66b16db62286646d94bcd04548161ddea39fca079113e49b187490f6927671ae  venctl-darwin-arm64.zip
75aa9d17a2b3142e14b9f0cadac1c4df6dbe8be0d9ae2def68989da061458cef  venctl-linux-amd64.zip
d0ac7c24dd10c830a59517b4173ab71a3aebe093be663e06fd94c963c1ba7c9f  venctl-linux-arm64.zip